### PR TITLE
Fix environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ ENV WOL_SLEEP_TIME 10
 ENV WOL_COMPUTER_NAMES ordi1,ordi2
 ENV WOL_COMPUTER_MACS 10:00:00:00:00:00,20:00:00:00:00:00
 ENV WOL_COMPUTER_LOCAL_IPS 192.168.1.1,192.168.1.2
-ENV HTTPS_PORT 2000
-ENV HTTP_PORT 2001
+ENV WOL_HTTPS_PORT 2000
+ENV WOL_HTTP_PORT 2001
 
 # Since we are uing network in host mode, this has no effect.
 # Find a way to run in bridge mode and this can then be restored.


### PR DESCRIPTION
HTTPS/HTTP environment variables should match with docker-entrypoint.sh in which they are named WOL_HTTP_PORT and WOL_HTTPS_PORT
Not doing it cause apache to crash the docker as the config file do not have any argument for "Listen"